### PR TITLE
Fix/typo html

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ The Getting Started with Modules tutorial provides developers with clear guideli
 
 To begin, simply navigate to the [Getting Started with Modules](https://designers.hubspot.com/tutorials/getting-started-with-modules) tutorial. The tutorial requires you to download the [HubSpot CMS Boilerplate theme](https://github.com/HubSpot/cms-theme-boilerplate). This theme is designed to offer developers a head start in the website building process. The boilerplate also represents HubSpot's [opinionated best practices](https://designers.hubspot.com/docs/building-blocks/themes/hubspot-cms-boilerplate).
 
-Because the boilerplate theme's code may change over time, we have decided to include only those files in the theme that developers will need to create or edit during the Getting Started with Modules Tutorial. These files include:
+Because the boilerplate theme's code may change over time, we have decided to include only the most critical files that developers will need to create or edit during the Getting Started with Modules Tutorial. These files include:
 
 1. Testimonial.module - the folder containing the files that make up the custom module we will build as part of the tutorial.
 2. homepage.html - the template that we will be editing to include our custom module.
+3. images - the folder containing the profile pictures we will use in the Testimonial module.
 
 To learn more about the HubSpot CMS, visit [developers.hubspot.com](https://designers.hubspot.com/docs?_ga=2.209474578.105050189.1584980358-1867732861.1581022431) and explore the documentation.

--- a/Testimonial.module/module.css
+++ b/Testimonial.module/module.css
@@ -6,7 +6,7 @@
   font-weight: bold;
 }
 
-.testmonial__picture {
+.testimonial__picture {
   display: block;
   margin: auto;
 }

--- a/Testimonial.module/module.html
+++ b/Testimonial.module/module.html
@@ -1,5 +1,5 @@
 <div class="testimonial">
   <h1 class="testimonial__header"> {{ module.customer_name }} </h1>
-  <img class="testmonial__picture" src={{ module.profile_pic.src }} alt={{ module.profile_pic.alt }}>
+  <img class="testimonial__picture" src={{ module.profile_pic.src }} alt={{ module.profile_pic.alt }}>
   {{ module.testimonial }}
 </div>


### PR DESCRIPTION
In this PR, I fixed a minor typo in the Testimonial module's HTML and CSS. The class name "testimonial__picture" was spelled as "testmonial__picture" in both the module.html and module.css files. 

I also took the opportunity to include a reference to the images folder in the README file to avoid any confusion. 